### PR TITLE
Fix erasing undetected selection

### DIFF
--- a/src/app/fate-dropdown.interface.ts
+++ b/src/app/fate-dropdown.interface.ts
@@ -4,6 +4,6 @@ export interface FateDropdown {
   value: any;
   valueChange: EventEmitter<any>;
   selectNext: () => void;
-  selectPrevious: () => void;
+  selecPrevious: () => void;
   confirmSelection: () => void;
 }

--- a/src/app/fate-dropdown.interface.ts
+++ b/src/app/fate-dropdown.interface.ts
@@ -4,6 +4,6 @@ export interface FateDropdown {
   value: any;
   valueChange: EventEmitter<any>;
   selectNext: () => void;
-  selecPrevious: () => void;
+  selectPrevious: () => void;
   confirmSelection: () => void;
 }

--- a/src/app/fate-input/fate-input.component.ts
+++ b/src/app/fate-input/fate-input.component.ts
@@ -171,7 +171,7 @@ export class FateInputComponent implements ControlValueAccessor, OnChanges, OnIn
       //
       // Note: It may make sense to delete the selection for normal text
       // input too but for now we only do it on deletion.
-      if (event.key === 'Backspace' || event.key === 'Delete' && this.selectionRange) {
+      if ((event.key === 'Backspace' || event.key === 'Delete') && this.selectionRange) {
         const node = this.selectionRange.commonAncestorContainer;
         console.debug('Deletion', node);
         if (node instanceof HTMLElement && !(node as HTMLElement).isContentEditable) {


### PR DESCRIPTION
When mouse-selecting text and dragging selection outside the target, the `click` event isn't catched, so, `selectionRange` is undefined. This logic fix avoid enter this block and throwing an Error.