### PR TITLE
fix(dropdown): typo in 'FateDropdown' interface method

### DIFF
--- a/src/app/example-mention-dropdown/example-mention-dropdown.component.ts
+++ b/src/app/example-mention-dropdown/example-mention-dropdown.component.ts
@@ -76,7 +76,7 @@ export class ExampleMentionDropdownComponent implements FateDropdown {
       this.selected = this.filteredList.length - 1;
     }
   };
-  public selecPrevious () {
+  public selectPrevious () {
     this.selected--;
     if (this.selected < 0) {
       this.selected = 0;

--- a/src/app/fate-dropdown.interface.ts
+++ b/src/app/fate-dropdown.interface.ts
@@ -4,6 +4,6 @@ export interface FateDropdown {
   value: any;
   valueChange: EventEmitter<any>;
   selectNext: () => void;
-  selecPrevious: () => void;
+  selectPrevious: () => void;
   confirmSelection: () => void;
 }

--- a/src/app/fate-input/fate-input.component.ts
+++ b/src/app/fate-input/fate-input.component.ts
@@ -217,7 +217,7 @@ export class FateInputComponent implements ControlValueAccessor, OnChanges, OnIn
       if (this.inlineAction) {
         if (event.key === 'Up' || event.key === 'ArrowUp') {
           stopDefault();
-          this.dropdownInstance.selecPrevious();
+          this.dropdownInstance.selectPrevious();
         } else if (event.key === 'Down' || event.key === 'ArrowDown') {
           stopDefault();
           this.dropdownInstance.selectNext();

--- a/src/app/fate-link-dropdown/fate-link-dropdown.component.ts
+++ b/src/app/fate-link-dropdown/fate-link-dropdown.component.ts
@@ -21,6 +21,6 @@ export class FateLinkDropdownComponent implements FateDropdown {
   }
 
   public selectNext () {};
-  public selecPrevious () {};
+  public selectPrevious () {};
   public confirmSelection () {};
 }


### PR DESCRIPTION
BRAKING CHANGE: The public method called `selecPrevious` was renamed to `selectPrevious`.